### PR TITLE
GM9PRO_sprout: Add face unlock support

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -437,3 +437,6 @@ PRODUCT_PACKAGES += \
 PRODUCT_PROPERTY_OVERRIDES += \
     ro.vendor.qti.config.zram=true \
     ro.vendor.qti.config.zramsize=536870912
+
+# Face unlock - Credit: @Tenshi2112
+TARGET_SUPPORT_FACE_UNLOCK := true


### PR DESCRIPTION
If package is available on ROM source, the ROM will be compiled with face unlock (Settings > Security).

Basically PR #1 but in a single file change instead of making mistake first. ;)